### PR TITLE
Don't include stream sinks in the pipeline

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -18,8 +18,7 @@ var pack = require('browser-pack');
 
 var pipeline = splicer.obj([
     'deps', [ deps(__dirname + '/browser/main.js') ],
-    'pack', [ pack({ raw: true }) ],
-    process.stdout
+    'pack', [ pack({ raw: true }) ]
 ]);
 
 pipeline.get('deps').push(through.obj(function (row, enc, next) {
@@ -27,6 +26,8 @@ pipeline.get('deps').push(through.obj(function (row, enc, next) {
     this.push(row);
     next();
 }));
+
+process.stdin.pipe(pipeline).pipe(process.stdout);
 ```
 
 Here the `deps` sub-pipeline is augmented with a post-transformation that


### PR DESCRIPTION
The documentation shouldn't suggest including stream sinks as part of
the pipeline, as this leads to incorrect behavior when the included
stream is a WritableStream.

Instead, the output of a pipeline should be piped to a stream sink.
