### PR TITLE
Don't include stream sinks in the pipeline [skip ci]

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -15,18 +15,22 @@ var splicer = require('labeled-stream-splicer');
 var through = require('through2');
 var deps = require('module-deps');
 var pack = require('browser-pack');
+var lstream = require('lstream');
 
 var pipeline = splicer.obj([
-    'deps', [ deps(__dirname + '/browser/main.js') ],
-    'pack', [ pack({ raw: true }) ],
-    process.stdout
+    'deps', [ deps() ],
+    'pack', [ pack({ raw: true }) ]
 ]);
+
+pipeline.get('deps').unshift(lstream());
 
 pipeline.get('deps').push(through.obj(function (row, enc, next) {
     row.source = row.source.toUpperCase();
     this.push(row);
     next();
 }));
+
+process.stdin.pipe(pipeline).pipe(process.stdout);
 ```
 
 Here the `deps` sub-pipeline is augmented with a post-transformation that


### PR DESCRIPTION
The documentation shouldn't suggest including stream sinks as part of
the pipeline, as this leads to incorrect behavior when the included
stream is a WritableStream.

Instead, the output of a pipeline should be piped to a stream sink.
