### PR TITLE
ci: update test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
 language: node_js
 node_js:
-  - "0.8"
+  - "12"
+  - "11"
+  - "10"
+  - "8"
+  - "6"
+  - "4"
+  - "iojs"
+  - "0.12"
   - "0.10"
+  - "0.8"
 before_install:
-  - npm install -g npm@~1.4.6
+  # Old npm certs are untrusted https://github.com/npm/npm/issues/20191
+  - 'if [ "${TRAVIS_NODE_VERSION}" = "0.6" ] || [ "${TRAVIS_NODE_VERSION}" = "0.8" ]; then export NPM_CONFIG_STRICT_SSL=false; fi'
+  - 'nvm install-latest-npm'


### PR DESCRIPTION
Adds 0.8, which browserify supports, and a bunch of newer versions.