### PR TITLE
Update dependencies, remove isarray

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var Splicer = require('stream-splicer');
 var inherits = require('inherits');
-var isarray = require('isarray');
 
 module.exports = Labeled;
 inherits(Labeled, Splicer);
@@ -19,7 +18,7 @@ function Labeled (streams, opts) {
     for (var i = 0; i < streams.length; i++) {
         var s = streams[i];
         if (typeof s === 'string') continue;
-        if (isarray(s)) {
+        if (Array.isArray(s)) {
             s = new Labeled(s, opts);
         }
         if (i >= 0 && typeof streams[i-1] === 'string') {

--- a/package.json
+++ b/package.json
@@ -5,14 +5,13 @@
   "main": "index.js",
   "dependencies": {
     "inherits": "^2.0.1",
-    "isarray": "^2.0.4",
     "stream-splicer": "^2.0.0"
   },
   "devDependencies": {
-    "browser-pack": "^6.0.4",
+    "browser-pack": "^6.1.0",
     "concat-stream": "^1.4.6",
-    "module-deps": "^6.0.0",
-    "tape": "^2.12.1",
+    "module-deps": "^6.2.0",
+    "tape": "^4.10.1",
     "through2": "^1.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Array.isArray is available on Node 0.8 so we don't need to import isarray.