### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,21 @@ node_js:
   - "0.12"
   - "0.10"
   - "0.8"
+
+arch:
+  - amd64
+  - ppc64le
+  
 before_install:
   # Old npm certs are untrusted https://github.com/npm/npm/issues/20191
   - 'if [ "${TRAVIS_NODE_VERSION}" = "0.6" ] || [ "${TRAVIS_NODE_VERSION}" = "0.8" ]; then export NPM_CONFIG_STRICT_SSL=false; fi'
-  - 'nvm install-latest-npm'
+  - 'nvm install-latest-npm'   
+
+jobs:
+  exclude:
+   - arch: ppc64le
+     node_js: "0.8"
+   - arch: ppc64le
+     node_js: "0.10"
+   - arch: ppc64le
+     node_js: "0.12"


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.