### PR TITLE
fix: remove unused dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "stream splicer with labels",
   "main": "index.js",
   "dependencies": {
-    "inherits": "^2.0.1",
     "stream-splicer": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi,

I found that one dependency (inherits) is not used in your package, according to your test. So I modified the package.json file to exclude the useless dependency. Would you consider removing useless dependencies from your package, so that developers do not need to install them when they use your package?